### PR TITLE
Tighten slice boundaries and define shared design assets

### DIFF
--- a/.codex/roles/developer-cjmp.md
+++ b/.codex/roles/developer-cjmp.md
@@ -25,12 +25,13 @@ Take the highest-priority unfinished `requirement` or `bug` issue that is ready 
 
 - Treat the selected GitHub issue as the execution source of truth.
 - Read the linked requirement, acceptance, and design artifacts before changing code.
-- Treat the framework-agnostic design resource set as implementation input, not optional reference material.
-  - `docs/design/figma-source/index.html`: framework-agnostic screen and layout source board
-  - `docs/design/assets/icons/`: canonical SVG icon source
-  - `docs/design/assets/mock-data.json`: canonical demo content and UI-state sample data
-- Use the shared SVG assets and mock data directly unless the issue explicitly requires a deviation.
-- Do not redraw, rename, or locally fork shared design assets without also updating the framework-agnostic design source.
+- Implement only what the selected issue explicitly allows.
+- Treat `Must Not Be Implemented Yet` in the linked requirement, acceptance, and design artifacts as a hard stop, not a soft suggestion.
+- If the issue, requirement, acceptance, design, or shared design asset contract disagree, stop and surface the mismatch before coding.
+- Use the canonical shared design asset contract at `docs/design/telegram-commercial-mvp-shared-assets.md` and the canonical shared source at `shared/design/telegram-commercial-mvp/`.
+- Copy required shared assets into the framework app's own asset directory before runtime use.
+- Do not invent framework-local tokens, copy, mock data, or placeholder resources unless the shared asset contract explicitly allows a framework-specific adaptation.
+- If the shared asset contract is insufficient for the selected slice, stop and raise the gap before continuing.
 - Do not invent features or polish that do not help expose, compare, or solve meaningful AI-efficiency problems.
 - Keep your framework implementation aligned with the framework-agnostic product slice so it remains comparable against the other framework versions.
 - Do not edit another framework lane unless the task explicitly requires cross-framework coordination.

--- a/.codex/roles/developer-flutter.md
+++ b/.codex/roles/developer-flutter.md
@@ -28,12 +28,13 @@ Take the highest-priority unfinished `requirement` or `bug` issue that is ready 
 
 - Treat the selected GitHub issue as the execution source of truth.
 - Read the linked requirement, acceptance, and design artifacts before changing code.
-- Treat the framework-agnostic design resource set as implementation input, not optional reference material.
-  - `docs/design/figma-source/index.html`: framework-agnostic screen and layout source board
-  - `docs/design/assets/icons/`: canonical SVG icon source
-  - `docs/design/assets/mock-data.json`: canonical demo content and UI-state sample data
-- Use the shared SVG assets and mock data directly unless the issue explicitly requires a deviation.
-- Do not redraw, rename, or locally fork shared design assets without also updating the framework-agnostic design source.
+- Implement only what the selected issue explicitly allows.
+- Treat `Must Not Be Implemented Yet` in the linked requirement, acceptance, and design artifacts as a hard stop, not a soft suggestion.
+- If the issue, requirement, acceptance, design, or shared design asset contract disagree, stop and surface the mismatch before coding.
+- Use the canonical shared design asset contract at `docs/design/telegram-commercial-mvp-shared-assets.md` and the canonical shared source at `shared/design/telegram-commercial-mvp/`.
+- Copy required shared assets into the framework app's own asset directory before runtime use.
+- Do not invent framework-local tokens, copy, mock data, or placeholder resources unless the shared asset contract explicitly allows a framework-specific adaptation.
+- If the shared asset contract is insufficient for the selected slice, stop and raise the gap before continuing.
 - Do not invent features or polish that do not help expose, compare, or solve meaningful AI-efficiency problems.
 - Keep your framework implementation aligned with the framework-agnostic product slice so it remains comparable against the other framework versions.
 - Do not edit another framework lane unless the task explicitly requires cross-framework coordination.

--- a/.codex/roles/developer-kmp.md
+++ b/.codex/roles/developer-kmp.md
@@ -26,12 +26,13 @@ Take the highest-priority unfinished `requirement` or `bug` issue that is ready 
 
 - Treat the selected GitHub issue as the execution source of truth.
 - Read the linked requirement, acceptance, and design artifacts before changing code.
-- Treat the framework-agnostic design resource set as implementation input, not optional reference material.
-  - `docs/design/figma-source/index.html`: framework-agnostic screen and layout source board
-  - `docs/design/assets/icons/`: canonical SVG icon source
-  - `docs/design/assets/mock-data.json`: canonical demo content and UI-state sample data
-- Use the shared SVG assets and mock data directly unless the issue explicitly requires a deviation.
-- Do not redraw, rename, or locally fork shared design assets without also updating the framework-agnostic design source.
+- Implement only what the selected issue explicitly allows.
+- Treat `Must Not Be Implemented Yet` in the linked requirement, acceptance, and design artifacts as a hard stop, not a soft suggestion.
+- If the issue, requirement, acceptance, design, or shared design asset contract disagree, stop and surface the mismatch before coding.
+- Use the canonical shared design asset contract at `docs/design/telegram-commercial-mvp-shared-assets.md` and the canonical shared source at `shared/design/telegram-commercial-mvp/`.
+- Copy required shared assets into the framework app's own asset directory before runtime use.
+- Do not invent framework-local tokens, copy, mock data, or placeholder resources unless the shared asset contract explicitly allows a framework-specific adaptation.
+- If the shared asset contract is insufficient for the selected slice, stop and raise the gap before continuing.
 - Do not invent features or polish that do not help expose, compare, or solve meaningful AI-efficiency problems.
 - Keep your framework implementation aligned with the framework-agnostic product slice so it remains comparable against the other framework versions.
 - Do not edit another framework lane unless the task explicitly requires cross-framework coordination.

--- a/docs/acceptance/README.md
+++ b/docs/acceptance/README.md
@@ -8,3 +8,4 @@ Recommended file contents:
 - edge cases
 - explicit pass/fail criteria
 - links to related requirement and design artifacts
+- slice-specific acceptance contracts when later slices must not be pulled forward early

--- a/docs/acceptance/telegram-commercial-mvp.md
+++ b/docs/acceptance/telegram-commercial-mvp.md
@@ -6,9 +6,208 @@ This document defines the acceptance scenarios for the Telegram-like commercial 
 
 Related requirement: `docs/requirements/telegram-commercial-mvp.md`
 Related design: `docs/design/telegram-commercial-mvp.md`
-Related design source board: `docs/design/figma-source/index.html`
-Related shared icon assets: `docs/design/assets/icons/`
-Related shared mock data: `docs/design/assets/mock-data.json`
+
+## Slice Acceptance Contracts
+
+The scenarios below describe the cumulative full-MVP behavior after slices `#1` through `#6` are complete.
+For issue-by-issue acceptance of slices `#1` through `#6`, use the contracts below instead of treating later-slice product behavior as early-slice acceptance scope.
+
+### Slice #1: App shell and startup routing
+
+#### Allowed In This Slice
+
+- bootstrap or loading gate
+- no-session handoff into login
+- startup failure state with recoverable fallback or explicit notice
+- authenticated route stub only if routing structure requires it
+
+#### Must Not Be Implemented Yet
+
+- demo verification
+- successful authenticated handoff after login
+- session persistence
+- session restore
+- home shell
+- chat list
+
+#### Temporary Placeholder Allowed
+
+- a minimal authenticated placeholder screen may exist behind the routing layer
+- the placeholder must not look like the real home shell or chat list
+
+#### Depends On Prior Slice Outputs
+
+- none
+
+#### Slice Pass Criteria
+
+- first launch without session reaches login cleanly
+- startup failure does not leave the app stuck on a spinner
+- any authenticated destination reachable in this slice is clearly a placeholder, not a later-slice implementation
+
+### Slice #2: Demo login flow
+
+#### Allowed In This Slice
+
+- phone input
+- continue CTA
+- validation and failure feedback
+- demo verification step
+- successful authenticated handoff into the authenticated placeholder
+
+#### Must Not Be Implemented Yet
+
+- session persistence
+- session restore on relaunch
+- real home shell
+- real chat list
+
+#### Temporary Placeholder Allowed
+
+- successful authentication may land on the authenticated placeholder from slice `#1`
+- the placeholder must not be presented as the real home shell
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` app shell and startup routing
+
+#### Slice Pass Criteria
+
+- the user can complete the demo login path without developer knowledge
+- invalid or incomplete input gets clear feedback
+- success ends in the authenticated placeholder handoff, not in the real home shell or chat list
+
+### Slice #3: Session restore
+
+#### Allowed In This Slice
+
+- local demo session persistence
+- restore on relaunch when the local session is valid
+- fallback to login when the local session is invalid or missing
+
+#### Must Not Be Implemented Yet
+
+- real home shell
+- real chat list
+- chat detail
+- composer
+
+#### Temporary Placeholder Allowed
+
+- restore may land on the same authenticated placeholder used in slice `#2`
+- the placeholder must not be mistaken for the real home shell or chat list
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` app shell and startup routing
+- slice `#2` demo login flow
+
+#### Slice Pass Criteria
+
+- relaunch with a valid local session lands in the authenticated placeholder without exposing broken intermediate states
+- invalid or missing session falls back to login cleanly
+- restore does not introduce the real home shell or chat list early
+
+### Slice #4: Home shell and chat list
+
+#### Allowed In This Slice
+
+- Telegram-like home shell
+- visible `Chats`, `Contacts`, and `Settings` tabs
+- `Chats` as the default active tab
+- chat list rows and metadata
+- loading, empty, and error states
+- stable list scrolling
+
+#### Must Not Be Implemented Yet
+
+- chat detail
+- composer
+- local send flow
+
+#### Temporary Placeholder Allowed
+
+- `Contacts` and `Settings` inner screens may be placeholder destinations
+- the placeholder destinations must look intentional and must not appear broken
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` app shell and startup routing
+- slice `#2` demo login flow
+- slice `#3` session restore
+
+#### Slice Pass Criteria
+
+- login and restore now land in the real home shell with `Chats` active
+- the home shell visibly includes `Chats`, `Contacts`, and `Settings`
+- the chat list meets the required metadata, state, and scrolling quality bar
+
+### Slice #5: Chat detail
+
+#### Allowed In This Slice
+
+- chat detail entry from the existing chat list
+- top bar with back navigation and conversation title
+- message history rendering
+- incoming and outgoing bubbles
+- date separators
+- stable scrolling for the shared seed conversation
+
+#### Must Not Be Implemented Yet
+
+- local text send flow
+- editable composer behavior
+- attachments, stickers, or voice notes
+- remote delivery receipts
+
+#### Temporary Placeholder Allowed
+
+- a non-interactive composer shell may exist to preserve the intended layout
+- the shell must not allow sending or local message append
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#4`
+
+#### Slice Pass Criteria
+
+- the user can open the shared seed conversation from the chat list
+- the conversation looks believable for a commercial messaging app
+- incoming and outgoing messages are visually distinct and grouped coherently
+- if a composer shell is present, it is clearly inactive and cannot send
+
+### Slice #6: Composer and local message send
+
+#### Allowed In This Slice
+
+- text input composer
+- send action
+- local message append
+- pending-to-sent transition
+- clear composer on success
+- recoverable local send failure state when applicable
+
+#### Must Not Be Implemented Yet
+
+- remote delivery receipts
+- attachments, stickers, or voice message compose
+- media gallery or advanced message actions
+
+#### Temporary Placeholder Allowed
+
+- non-text composer affordances may remain absent or inert
+- local send may remain local-only and must not pretend to contact a real backend
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#5`
+
+#### Slice Pass Criteria
+
+- sending a local text message works from chat detail
+- the local message appears immediately and settles into a stable state
+- the composer clears after success
+- any failure state remains recoverable without leaving the conversation broken
 
 ## Acceptance Scenario 1: First Launch Routes To Login
 
@@ -138,8 +337,8 @@ Related shared mock data: `docs/design/assets/mock-data.json`
 ## Cross-Framework Acceptance Rule
 
 - the same scenario set applies to `CJMP`, `KMP`, and `flutter`
-- acceptance should validate against the shared design resource set, not against framework-local restatements of the same UI assets or demo content
 - if one framework deviates, the difference must be recorded in the relevant framework round log and later reflected in `reports/comparison/telegram-commercial-mvp-comparison-overview.md`
+- use the slice acceptance contracts above to prevent early implementation of later slices
 
 ## Rejection Conditions
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,7 +7,4 @@ Recommended file contents:
 - screen inventory
 - interaction states
 - Figma links or node references
-- reusable design assets under `docs/design/assets/`
-- source boards under `docs/design/figma-source/`
-
-If a design asset can be consumed directly by `CJMP`, `KMP`, and `flutter`, keep it as a shared machine-consumable resource instead of repeating it in framework-local code or prose.
+- shared design asset contract links when the slice depends on canonical shared tokens, copy, or mock data

--- a/docs/design/telegram-commercial-mvp-shared-assets.md
+++ b/docs/design/telegram-commercial-mvp-shared-assets.md
@@ -1,0 +1,105 @@
+# Telegram Commercial MVP Shared Design Assets
+
+## Goal
+
+Define the canonical shared design asset contract for the Telegram commercial MVP so that `CJMP`, `KMP`, and `flutter` implementations use the same tokens, copy, mock data, and placeholder resources.
+
+## Canonical Source
+
+- shared asset spec: `docs/design/telegram-commercial-mvp-shared-assets.md`
+- concrete shared asset source: `shared/design/telegram-commercial-mvp/`
+
+The shared source directory is the only canonical source of concrete machine-consumable design assets for this MVP.
+
+## Copy Rule
+
+- each framework app must copy the required shared assets into its own local app asset directory before runtime use
+- framework apps must preserve filenames and JSON structure when copying unless the framework requires a trivial packaging wrapper
+- framework apps must never load runtime assets directly from `shared/design/telegram-commercial-mvp/`
+- if a required shared asset is missing from the canonical source, implementation must stop and surface the gap instead of inventing a local replacement
+
+## Required Asset Categories
+
+### Design Tokens
+
+Canonical file:
+
+- `shared/design/telegram-commercial-mvp/design-tokens.json`
+
+Required token groups:
+
+- colors
+- typography scale
+- spacing scale
+- radii
+- border widths
+- elevation or shadow levels
+- icon sizes
+- avatar sizes
+
+### Shared Copy
+
+Canonical file:
+
+- `shared/design/telegram-commercial-mvp/shared-copy.json`
+
+Required shared copy:
+
+- bootstrap copy
+- login copy
+- home shell tab labels
+- chat list loading, empty, and error copy
+- chat detail title fallback and composer copy
+- local-send failure copy that affects parity
+- later-slice placeholder copy that affects parity
+
+### Shared Mock Data
+
+Canonical file:
+
+- `shared/design/telegram-commercial-mvp/shared-mock-data.json`
+
+Required shared mock data:
+
+- startup and login seed data
+- home shell tab metadata
+- chat list seed conversations
+- later-slice chat detail placeholder data
+- local-send behavior metadata shared across frameworks
+
+### Shared Placeholder Resources
+
+Canonical files:
+
+- `shared/design/telegram-commercial-mvp/resource-manifest.json`
+- `shared/design/telegram-commercial-mvp/resources/app-mark.svg`
+- `shared/design/telegram-commercial-mvp/resources/avatar-placeholder.svg`
+
+Required resource coverage:
+
+- app-level placeholder logo mark if needed
+- default avatar placeholder
+- any required illustration or icon resource that cannot be represented cleanly as token or JSON data
+
+## Existing Narrow Asset Pattern
+
+A startup or login-only JSON catalog such as a single `mock-data.json` file is not sufficient as the shared design asset layer.
+
+That narrower pattern can cover early copy needs, but it does not define:
+
+- design tokens
+- home shell tab metadata
+- chat list seed data
+- chat detail and local-send behavior metadata
+- placeholder resources
+
+So framework implementations must use the full shared asset contract above instead of treating a startup-only JSON file as the whole shared asset layer.
+
+## Minimum Consumer Behavior
+
+Every framework implementation must:
+
+1. read the shared asset spec before implementation
+2. copy the required canonical files into the framework app project
+3. use shared tokens, shared copy, shared mock data, and shared placeholder resources as the default source of truth
+4. stop and surface any missing shared asset instead of creating a framework-local replacement

--- a/docs/design/telegram-commercial-mvp.md
+++ b/docs/design/telegram-commercial-mvp.md
@@ -9,20 +9,19 @@ Related acceptance: `docs/acceptance/telegram-commercial-mvp.md`
 
 ## Figma Status
 
-- Figma artifact: capture started, final file generation still pending browser-side submission
-- Figma HTML source board: `docs/design/figma-source/index.html`
-- Shared icon assets: `docs/design/assets/icons/`
-- Shared mock data: `docs/design/assets/mock-data.json`
-- Until the Figma file is fully generated, this document, the HTML source board, the shared icon assets, and the shared mock data are the source of truth for framework-agnostic design decisions.
+- Figma artifact: pending
+- Until the Figma file is created, this document is the source of truth for framework-agnostic design decisions.
 
-## Shared Design Resources
+## Shared Design Asset Contract
 
-- `docs/design/figma-source/index.html`: screen inventory and layout source board
-- `docs/design/assets/icons/`: canonical SVG icon source for all framework lanes
-- `docs/design/assets/mock-data.json`: canonical demo content and UI-state sample data for all framework lanes
-- `docs/design/assets/README.md`: usage contract for shared design assets
+- shared asset spec: `docs/design/telegram-commercial-mvp-shared-assets.md`
+- canonical shared asset source: `shared/design/telegram-commercial-mvp/`
+- framework apps must copy required shared assets into their own local app asset paths before runtime use
+- framework apps must not load runtime assets directly from the shared source directory
+- if a required shared asset is missing, implementations must stop and surface the gap instead of inventing a local replacement
 
-All three framework lanes should consume these shared resources directly instead of recreating near-duplicate design assets or demo content locally.
+The existing startup or login-only JSON catalog pattern is not sufficient as the full shared design asset layer.
+The canonical shared asset contract now includes tokens, shared copy, shared mock data, and placeholder resources.
 
 ## Product Structure
 
@@ -31,6 +30,174 @@ All three framework lanes should consume these shared resources directly instead
 - Home shell
 - Chat list
 - Chat detail
+
+## Slice Design Contracts
+
+### Slice #1: App shell and startup routing
+
+#### Allowed In This Slice
+
+- startup loading gate
+- login handoff state
+- startup failure state
+- minimal route structure needed for authenticated and unauthenticated destinations
+- shared assets limited to the startup and login subset
+
+#### Must Not Be Implemented Yet
+
+- demo verification UI
+- persistent session behavior
+- real home shell
+- real chat list surface
+- chat rows
+
+#### Temporary Placeholder Allowed
+
+- a minimal authenticated placeholder screen may exist if the route structure requires it
+- the placeholder must not borrow the home shell tabs or chat list composition
+
+#### Depends On Prior Slice Outputs
+
+- shared design tokens
+- shared startup and login copy
+- shared startup and login mock data
+
+### Slice #2: Demo login flow
+
+#### Allowed In This Slice
+
+- phone entry UI
+- verification step UI
+- validation and failure states
+- authenticated handoff into the existing placeholder destination
+
+#### Must Not Be Implemented Yet
+
+- session persistence
+- session restore
+- real home shell
+- real chat list
+
+#### Temporary Placeholder Allowed
+
+- continue to use the authenticated placeholder from slice `#1`
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` route structure and placeholder destination
+- shared startup and login copy
+- shared startup and login mock data
+
+### Slice #3: Session restore
+
+#### Allowed In This Slice
+
+- persistence and restore state wiring
+- login fallback state
+- restore-time loading and failure messaging
+
+#### Must Not Be Implemented Yet
+
+- real home shell
+- real chat list
+- chat detail
+- composer
+
+#### Temporary Placeholder Allowed
+
+- restore may still land on the authenticated placeholder until slice `#4` ships
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` route structure
+- slice `#2` authenticated placeholder and login handoff
+- shared startup and login copy
+
+### Slice #4: Home shell and chat list
+
+#### Allowed In This Slice
+
+- real home shell
+- `Chats`, `Contacts`, and `Settings` tabs
+- shared home shell tab metadata
+- chat list rows and state surfaces
+- chat list mock data and placeholder avatar resources
+
+#### Must Not Be Implemented Yet
+
+- chat detail
+- composer
+- local send flow
+
+#### Temporary Placeholder Allowed
+
+- `Contacts` and `Settings` destinations may remain placeholders
+- placeholders must still use shared copy and tokens
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#3`
+- shared design tokens
+- shared home shell copy and tab metadata
+- shared chat list mock data
+- shared placeholder resources
+
+### Slice #5: Chat detail
+
+#### Allowed In This Slice
+
+- chat detail route and conversation selection handoff
+- top bar with title and back navigation
+- shared seed conversation history
+- incoming and outgoing bubble styles
+- date separators
+- shared placeholder avatar resources where needed
+
+#### Must Not Be Implemented Yet
+
+- interactive text composer behavior
+- local message append
+- attachments, stickers, or voice notes
+- remote sync or delivery receipts
+
+#### Temporary Placeholder Allowed
+
+- a non-interactive composer shell may be shown to preserve the intended layout
+- if shown, it must use shared copy and tokens and remain inactive
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#4`
+- shared chat detail copy
+- shared chat detail mock data
+- shared placeholder resources
+
+### Slice #6: Composer and local message send
+
+#### Allowed In This Slice
+
+- text composer field
+- send action
+- local message append using shared local-send behavior metadata
+- pending, sent, and failure states for the local-only send path
+- composer clear-on-success behavior
+
+#### Must Not Be Implemented Yet
+
+- remote delivery receipts
+- non-text composer actions as real features
+- media gallery or advanced message actions
+
+#### Temporary Placeholder Allowed
+
+- non-text composer affordances may remain absent or inert
+- the local send path may remain fully local-only
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#5`
+- shared chat detail copy
+- shared chat detail mock data, including local-send behavior metadata
 
 ## Screen Inventory
 
@@ -122,6 +289,7 @@ All three framework lanes should consume these shared resources directly instead
 - do not leak framework-specific state containers or architectural decisions into the UI spec
 - prefer reusable structural components across all three frameworks
 - define the major states that materially affect implementation complexity and acceptance
+- do not treat framework-local assets as acceptable substitutes for missing shared design assets
 
 ## Figma Follow-Up
 

--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -9,3 +9,4 @@ Recommended file contents:
 - assumptions
 - non-goals
 - links to the driving github issues
+- explicit slice delivery contracts when the work is split across multiple requirement issues

--- a/docs/requirements/telegram-commercial-mvp-breakdown.md
+++ b/docs/requirements/telegram-commercial-mvp-breakdown.md
@@ -5,6 +5,9 @@
 - requirement: `docs/requirements/telegram-commercial-mvp.md`
 - acceptance: `docs/acceptance/telegram-commercial-mvp.md`
 - design: `docs/design/telegram-commercial-mvp.md`
+- shared design assets: `docs/design/telegram-commercial-mvp-shared-assets.md`
+
+Issue-by-issue implementation of slices `#1` through `#4` must follow the slice delivery contracts in the linked requirement, acceptance, and design artifacts.
 
 ## Requirement Issues
 

--- a/docs/requirements/telegram-commercial-mvp.md
+++ b/docs/requirements/telegram-commercial-mvp.md
@@ -75,18 +75,186 @@ The MVP must be strong enough to expose real product, UI, state-management, navi
 5. Chat detail
 6. Composer and local message send
 
+## Slice Delivery Contracts
+
+The full-MVP user flows above describe the cumulative product end state after all slices are delivered.
+Issue-by-issue delivery must follow the slice contracts below instead of pulling later behavior forward early.
+
+### Slice #1: App shell and startup routing
+
+#### Allowed In This Slice
+
+- bootstrap or loading gate
+- route to login when no valid session exists
+- startup failure state with recoverable fallback or explicit notice
+- route graph or app shell structure only as needed to support the startup handoff
+
+#### Must Not Be Implemented Yet
+
+- demo verification step
+- login success flow beyond a minimal authenticated handoff
+- session persistence
+- session restore
+- real home shell
+- chat list surface
+- chat rows
+
+#### Temporary Placeholder Allowed
+
+- a minimal authenticated destination stub only if the route structure requires it
+- the authenticated stub must not look like the real home shell or chat list
+
+#### Depends On Prior Slice Outputs
+
+- none
+
+### Slice #2: Demo login flow
+
+#### Allowed In This Slice
+
+- phone input
+- primary continue CTA
+- validation and failure feedback
+- demo verification step
+- successful authenticated handoff after demo verification
+
+#### Must Not Be Implemented Yet
+
+- session persistence
+- session restore on relaunch
+- real home shell
+- real chat list
+
+#### Temporary Placeholder Allowed
+
+- successful authentication may route to the same authenticated placeholder from slice `#1`
+- the placeholder must not become the real home shell
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` app shell and startup routing
+
+### Slice #3: Session restore
+
+#### Allowed In This Slice
+
+- persist a valid local demo session
+- restore a valid local demo session on relaunch
+- invalid-session fallback to login
+
+#### Must Not Be Implemented Yet
+
+- real home shell
+- real chat list
+- chat detail
+- composer
+- local send flow
+
+#### Temporary Placeholder Allowed
+
+- restore may land on the same authenticated placeholder used in slice `#2`
+- the restored placeholder must not be presented as the real home shell or chat list
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` app shell and startup routing
+- slice `#2` demo login flow
+
+### Slice #4: Home shell and chat list
+
+#### Allowed In This Slice
+
+- Telegram-like home shell
+- visible `Chats`, `Contacts`, and `Settings` tabs
+- `Chats` as the default active tab
+- chat list surface
+- conversation rows with shared mock data
+- loading, empty, and error states
+- stable list scrolling
+
+#### Must Not Be Implemented Yet
+
+- chat detail
+- composer
+- local send flow
+
+#### Temporary Placeholder Allowed
+
+- `Contacts` and `Settings` inner destinations may remain placeholder screens in the MVP
+- placeholder destinations must look intentional and must not appear broken
+
+#### Depends On Prior Slice Outputs
+
+- slice `#1` app shell and startup routing
+- slice `#2` demo login flow
+- slice `#3` session restore
+
+### Slice #5: Chat detail
+
+#### Allowed In This Slice
+
+- chat detail route and back navigation
+- top bar with conversation title
+- message history rendering
+- incoming and outgoing bubbles
+- date separators
+- stable scrolling for the shared seed conversation
+- delivery-state cues for existing shared mock messages
+
+#### Must Not Be Implemented Yet
+
+- local text send flow
+- editable composer behavior
+- attachments, stickers, or voice notes
+- remote sync or delivery receipts
+
+#### Temporary Placeholder Allowed
+
+- a non-interactive composer shell may be shown if needed to preserve the intended layout
+- any composer shell shown in this slice must not allow sending or local message append
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#4`
+
+### Slice #6: Composer and local message send
+
+#### Allowed In This Slice
+
+- text input composer
+- send action
+- local message append
+- pending-to-sent transition
+- clear composer on success
+- recoverable local send failure state when applicable
+
+#### Must Not Be Implemented Yet
+
+- remote delivery receipts
+- attachments, stickers, or voice message compose
+- media gallery or advanced message actions
+
+#### Temporary Placeholder Allowed
+
+- non-text composer affordances may remain absent or inert
+- local send may stay fully local-only and must not pretend to contact a real backend
+
+#### Depends On Prior Slice Outputs
+
+- slices `#1` through `#5`
+
 ## Cross-Framework Delivery Rule
 
 Each approved requirement slice must be implemented for `CJMP`, `KMP`, and `flutter`.
 If one framework is behind, the comparison artifact must record the gap explicitly instead of silently collapsing scope.
+Each slice must also use the canonical shared design asset contract and source directory instead of inventing framework-local variants.
 
 ## Artifact Links
 
 - acceptance: `docs/acceptance/telegram-commercial-mvp.md`
 - design: `docs/design/telegram-commercial-mvp.md`
-- design source board: `docs/design/figma-source/index.html`
-- shared icon assets: `docs/design/assets/icons/`
-- shared mock data: `docs/design/assets/mock-data.json`
+- shared design assets: `docs/design/telegram-commercial-mvp-shared-assets.md`
+- shared design asset source: `shared/design/telegram-commercial-mvp/`
 - aggregate comparison: `reports/comparison/telegram-commercial-mvp-comparison-overview.md`
 - `CJMP` round log: `reports/comparison/telegram-commercial-mvp-cjmp-rounds.md`
 - `KMP` round log: `reports/comparison/telegram-commercial-mvp-kmp-rounds.md`

--- a/shared/design/telegram-commercial-mvp/README.md
+++ b/shared/design/telegram-commercial-mvp/README.md
@@ -1,0 +1,6 @@
+# Telegram Commercial MVP Shared Design Assets
+
+This directory is the canonical source of concrete shared design assets for the Telegram commercial MVP.
+
+Framework apps must copy the required files into their own local asset directories before runtime use.
+Framework apps must not load runtime assets directly from this shared source directory.

--- a/shared/design/telegram-commercial-mvp/design-tokens.json
+++ b/shared/design/telegram-commercial-mvp/design-tokens.json
@@ -1,0 +1,102 @@
+{
+  "meta": {
+    "name": "telegram-commercial-mvp",
+    "version": "1.0.0"
+  },
+  "color": {
+    "surface": {
+      "appBackground": "#F4F6F8",
+      "screen": "#FFFFFF",
+      "subtle": "#EEF2F6",
+      "elevated": "#FFFFFF"
+    },
+    "text": {
+      "primary": "#17212B",
+      "secondary": "#5B6B7A",
+      "muted": "#8393A3",
+      "inverse": "#FFFFFF"
+    },
+    "accent": {
+      "brand": "#2AABEE",
+      "brandStrong": "#229ED9",
+      "brandSoft": "#E7F6FD"
+    },
+    "status": {
+      "success": "#34C759",
+      "warning": "#F59E0B",
+      "error": "#E5484D"
+    },
+    "border": {
+      "subtle": "#D9E2EC",
+      "strong": "#B7C4D1"
+    },
+    "badge": {
+      "unreadBackground": "#2AABEE",
+      "unreadText": "#FFFFFF"
+    },
+    "avatar": {
+      "blue": "#D9ECFA",
+      "green": "#DDF3E4",
+      "orange": "#FCE8D6",
+      "purple": "#E9E0FB"
+    }
+  },
+  "typography": {
+    "family": {
+      "primary": "system-sans"
+    },
+    "size": {
+      "caption": 12,
+      "body": 14,
+      "bodyStrong": 15,
+      "title": 20,
+      "headline": 28
+    },
+    "lineHeight": {
+      "caption": 16,
+      "body": 20,
+      "bodyStrong": 22,
+      "title": 26,
+      "headline": 34
+    },
+    "weight": {
+      "regular": 400,
+      "medium": 500,
+      "semibold": 600,
+      "bold": 700
+    }
+  },
+  "spacing": {
+    "xs": 4,
+    "sm": 8,
+    "md": 12,
+    "lg": 16,
+    "xl": 24,
+    "xxl": 32
+  },
+  "radius": {
+    "card": 18,
+    "field": 14,
+    "pill": 999,
+    "bubble": 20
+  },
+  "borderWidth": {
+    "hairline": 1,
+    "strong": 2
+  },
+  "elevation": {
+    "none": 0,
+    "card": 2,
+    "overlay": 8
+  },
+  "iconSize": {
+    "sm": 16,
+    "md": 20,
+    "lg": 24,
+    "xl": 28
+  },
+  "avatarSize": {
+    "list": 40,
+    "detail": 48
+  }
+}

--- a/shared/design/telegram-commercial-mvp/resource-manifest.json
+++ b/shared/design/telegram-commercial-mvp/resource-manifest.json
@@ -1,0 +1,20 @@
+{
+  "sourceRoot": "shared/design/telegram-commercial-mvp",
+  "resources": [
+    {
+      "id": "app-mark",
+      "source": "resources/app-mark.svg",
+      "requiredBySlices": [1, 2, 3, 4]
+    },
+    {
+      "id": "avatar-placeholder",
+      "source": "resources/avatar-placeholder.svg",
+      "requiredBySlices": [4, 5]
+    }
+  ],
+  "copyRule": {
+    "copyIntoFrameworkApp": true,
+    "preserveFilenames": true,
+    "allowDirectRuntimeReadFromSharedSource": false
+  }
+}

--- a/shared/design/telegram-commercial-mvp/resources/app-mark.svg
+++ b/shared/design/telegram-commercial-mvp/resources/app-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <rect width="128" height="128" rx="32" fill="#2AABEE"/>
+  <path d="M29 61.5L96 34L83.5 95L61 73.5L47 85L49.5 65.5L29 61.5Z" fill="white"/>
+</svg>

--- a/shared/design/telegram-commercial-mvp/resources/avatar-placeholder.svg
+++ b/shared/design/telegram-commercial-mvp/resources/avatar-placeholder.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" fill="none">
+  <circle cx="40" cy="40" r="40" fill="#D9ECFA"/>
+  <circle cx="40" cy="31" r="14" fill="#7FAFD1"/>
+  <path d="M18 65C20.5 53.5 29 48 40 48C51 48 59.5 53.5 62 65" fill="#7FAFD1"/>
+</svg>

--- a/shared/design/telegram-commercial-mvp/shared-copy.json
+++ b/shared/design/telegram-commercial-mvp/shared-copy.json
@@ -1,0 +1,39 @@
+{
+  "bootstrap": {
+    "title": "Loading Telegram Demo...",
+    "body": "Preparing startup routing and shared design assets before the first-launch handoff.",
+    "failureNotice": "Shared design assets failed to load. The app is using embedded fallback content."
+  },
+  "login": {
+    "brandTitle": "Telegram Demo",
+    "headline": "Start with your phone number",
+    "body": "Complete the demo sign-in flow to unlock the authenticated app shell.",
+    "phoneLabel": "Phone number",
+    "phoneHint": "+1 415 555 0199",
+    "continueLabel": "Continue",
+    "footer": "Demo verification is local-only and does not contact a real backend.",
+    "invalidInputNotice": "Enter a valid demo phone number to continue."
+  },
+  "homeShell": {
+    "tabs": {
+      "chats": "Chats",
+      "contacts": "Contacts",
+      "settings": "Settings"
+    },
+    "placeholderNotice": "This destination is intentionally scoped as a placeholder in the current MVP slice."
+  },
+  "chatList": {
+    "title": "Telegram",
+    "loading": "Loading conversations...",
+    "emptyTitle": "No chats yet",
+    "emptyBody": "Shared seed conversations have not been loaded.",
+    "errorTitle": "Couldn't load chats",
+    "errorBody": "Check shared mock data and retry."
+  },
+  "chatDetail": {
+    "titleFallback": "Conversation",
+    "composerPlaceholder": "Message",
+    "sendLabel": "Send",
+    "sendFailureNotice": "The local demo message could not be sent. Try again."
+  }
+}

--- a/shared/design/telegram-commercial-mvp/shared-mock-data.json
+++ b/shared/design/telegram-commercial-mvp/shared-mock-data.json
@@ -1,0 +1,90 @@
+{
+  "startup": {
+    "defaultAuthenticatedDestination": "authenticated-placeholder"
+  },
+  "homeShell": {
+    "defaultTab": "chats",
+    "tabs": [
+      {
+        "id": "chats",
+        "labelKey": "homeShell.tabs.chats",
+        "iconId": "chat-bubble",
+        "implementedInSlice": 4
+      },
+      {
+        "id": "contacts",
+        "labelKey": "homeShell.tabs.contacts",
+        "iconId": "contacts",
+        "implementedInSlice": 4,
+        "placeholderDestination": true
+      },
+      {
+        "id": "settings",
+        "labelKey": "homeShell.tabs.settings",
+        "iconId": "settings",
+        "implementedInSlice": 4,
+        "placeholderDestination": true
+      }
+    ]
+  },
+  "chatList": {
+    "conversations": [
+      {
+        "id": "chat-alex",
+        "title": "Alex Mason",
+        "snippet": "Let's keep the startup slice tight for all three frameworks.",
+        "timestamp": "09:41",
+        "unreadCount": 2,
+        "pinned": true,
+        "muted": false,
+        "avatarResource": "avatar-placeholder.svg",
+        "avatarTint": "blue"
+      },
+      {
+        "id": "chat-design",
+        "title": "Design Sync",
+        "snippet": "Shared assets should prevent each framework from inventing its own look.",
+        "timestamp": "Yesterday",
+        "unreadCount": 0,
+        "pinned": false,
+        "muted": true,
+        "avatarResource": "avatar-placeholder.svg",
+        "avatarTint": "purple"
+      },
+      {
+        "id": "chat-ops",
+        "title": "Ops Bot",
+        "snippet": "Build is green. Token and time metrics were recorded.",
+        "timestamp": "Thu",
+        "unreadCount": 1,
+        "pinned": false,
+        "muted": false,
+        "avatarResource": "avatar-placeholder.svg",
+        "avatarTint": "green"
+      }
+    ]
+  },
+  "chatDetail": {
+    "placeholderConversationId": "chat-alex",
+    "messages": [
+      {
+        "id": "msg-1",
+        "direction": "incoming",
+        "text": "Later slices will turn this placeholder into the real chat detail screen.",
+        "deliveryState": "sent"
+      },
+      {
+        "id": "msg-2",
+        "direction": "outgoing",
+        "text": "For now, this data exists only to prevent frameworks from inventing their own seed content.",
+        "deliveryState": "sent"
+      }
+    ],
+    "localSend": {
+      "initialDeliveryState": "pending",
+      "settledDeliveryState": "sent",
+      "failureDeliveryState": "failed",
+      "clearComposerOnSuccess": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- tighten MVP slice boundaries for requirement issues #1 through #6
- add a canonical shared design asset contract and shared asset source
- require all three developer lanes to stop on boundary mismatches and copy canonical shared assets into app-local asset paths

## Validation
- parsed shared asset JSON files successfully
- synced GitHub issues #1 through #6 to the same boundary structure used in repo docs
